### PR TITLE
perf: precompile bytecode into the Flatpak image

### DIFF
--- a/io.github.mpvqc.mpvQC.yml
+++ b/io.github.mpvqc.mpvQC.yml
@@ -319,6 +319,11 @@ modules:
       - install -D build/release/main.py /app/share/$FLATPAK_ID/main.py
       - install -D build/release/rc_project.py /app/share/$FLATPAK_ID/rc_project.py
 
+      # Bake bytecode caches into the read-only image. unchecked-hash (PEP 552) is
+      # required: ostree normalizes mtimes, which invalidates timestamp-based .pyc.
+      # PySide6/scripts ships Jinja templates with a .py suffix, so skip it.
+      - /usr/bin/python3 -m compileall -q --invalidation-mode unchecked-hash -x 'PySide6/scripts' /app/share/$FLATPAK_ID /app/lib/python3.*/site-packages
+
       # Install Flatpak integration files
       - install -Dm644 io.github.mpvqc.mpvQC.svg /app/share/icons/hicolor/scalable/apps/io.github.mpvqc.mpvQC.svg
       - install -Dm644 io.github.mpvqc.mpvQC.desktop /app/share/applications/io.github.mpvqc.mpvQC.desktop
@@ -342,8 +347,7 @@ modules:
           type: json
           url: https://api.github.com/repos/casey/just/releases/latest
           version-query: .tag_name
-          url-query: .assets[] | select(.name == "just-" + $version + "-x86_64-unknown-linux-musl.tar.gz")
-            | .browser_download_url
+          url-query: .assets[] | select(.name == "just-" + $version + "-x86_64-unknown-linux-musl.tar.gz") | .browser_download_url
           timestamp-query: .published_at
       - type: archive
         url: https://github.com/astral-sh/uv/releases/download/0.11.24/uv-x86_64-unknown-linux-musl.tar.gz
@@ -354,8 +358,7 @@ modules:
           type: json
           url: https://api.github.com/repos/astral-sh/uv/releases/latest
           version-query: .tag_name
-          url-query: .assets[] | select(.name == "uv-x86_64-unknown-linux-musl.tar.gz")
-            | .browser_download_url
+          url-query: .assets[] | select(.name == "uv-x86_64-unknown-linux-musl.tar.gz") | .browser_download_url
           timestamp-query: .published_at
 
       - type: file

--- a/io.github.mpvqc.mpvQC.yml
+++ b/io.github.mpvqc.mpvQC.yml
@@ -317,7 +317,7 @@ modules:
       - mkdir -p /app/share/$FLATPAK_ID
       - cp -r build/release/mpvqc /app/share/$FLATPAK_ID
       - install -D build/release/main.py /app/share/$FLATPAK_ID/main.py
-      - install -D build/release/rc_project.py /app/share/$FLATPAK_ID/rc_project.py
+      - install -D build/release/project.rcc /app/share/$FLATPAK_ID/project.rcc
 
       # Bake bytecode caches into the read-only image. unchecked-hash (PEP 552) is
       # required: ostree normalizes mtimes, which invalidates timestamp-based .pyc.


### PR DESCRIPTION
The app directory under /app is read-only at runtime, so CPython can never write __pycache__ and re-parses every Python source on each launch. This build step bakes the bytecode caches into the image instead.

Two details matter and are easy to break by accident:

- `--invalidation-mode unchecked-hash` (PEP 552) is required, not optional. ostree normalizes file mtimes on deploy, which permanently invalidates timestamp-based .pyc files. With the default mode the caches would sit in the image and never be used.
- `PySide6/scripts` is excluded because PySide6's deploy tooling ships Jinja templates with a .py suffix that are not valid Python and would fail the build.

## Measured results

Local A/B on this machine (same runtime, warm starts, median of 5): importing the full mpvqc package drops from 167 ms (from source) to 124 ms (from .pyc), and site-packages compilation covers the handful of library modules that load at boot. Combined with mpvqc/mpvQC#358 the warm launch went from 388 ms to 299 ms; the caches contribute roughly half of that. Checked with python -v inside the sandbox that the deployed caches are hash-based and actually used at runtime.

## Merge gate

Do not merge before a mpvQC release containing mpvqc/mpvQC#358 exists. The second commit switches the install line to the binary project.rcc bundle, which earlier tags do not produce, so the source tag bump to that release must land in this PR before merging. The compileall commit on its own would already help the current rc_project.py-based releases.

The two url-query line rewraps are yamlfmt canonicalizing the file while it was touched, no functional change.